### PR TITLE
chore: update deps for laravel 11

### DIFF
--- a/system/composer.json
+++ b/system/composer.json
@@ -6,11 +6,11 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "guzzlehttp/guzzle": "^7.8",
+        "guzzlehttp/guzzle": "^7.10",
         "imangazaliev/didom": "^2.0",
         "laravel/framework": "^11.0",
-        "laravel/sanctum": "^4.0",
-        "laravel/tinker": "^2.9",
+        "laravel/sanctum": "^4.2",
+        "laravel/tinker": "^2.10",
         "simplesoftwareio/simple-qrcode": "^4.2",
         "torann/geoip": "^3.0",
         "xendit/xendit-php": "^2.17"

--- a/system/composer.lock
+++ b/system/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cccf550b312a282a993e71e2b741883",
+    "content-hash": "007ac086dc6fc8ec0832d8acb49888ba",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
## Summary
- align Guzzle, Sanctum, and Tinker dependencies with Laravel 11
- run composer update to refresh lockfile

## Testing
- `./vendor/bin/phpunit` *(fails: Target [Illuminate\Contracts\Debug\ExceptionHandler] is not instantiable while building [Spatie\LaravelIgnition\IgnitionServiceProvider])*

------
https://chatgpt.com/codex/tasks/task_e_68af110812d08329a11b224b7a90813c