### PR TITLE
Use stable laravel ignition

### DIFF
--- a/system/composer.json
+++ b/system/composer.json
@@ -16,7 +16,7 @@
         "xendit/xendit-php": "^2.17"
     },
     "require-dev": {
-        "spatie/laravel-ignition": "dev-laravel-11-exception-handling as 3.0.0",
+        "spatie/laravel-ignition": "^3.0",
         "fakerphp/faker": "^1.9.1",
         "laravel/sail": "^1.18",
         "mockery/mockery": "^1.5",
@@ -60,6 +60,5 @@
         "preferred-install": "dist",
         "sort-packages": true
     },
-    "minimum-stability": "dev",
     "prefer-stable": true
 }


### PR DESCRIPTION
## Summary
- switch laravel ignition to the ^3.0 stable release
- drop dev minimum-stability flag

## Testing
- `composer update spatie/laravel-ignition` *(fails: package constraint not satisfiable)*
- `php vendor/bin/phpunit` *(fails: Call to undefined method Illuminate\Foundation\Application::configure()*

------
https://chatgpt.com/codex/tasks/task_e_68af123dbc648329b8b18b5ed4c0ef20