### PR TITLE
Replace commands routing key with console

### DIFF
--- a/system/bootstrap/app.php
+++ b/system/bootstrap/app.php
@@ -9,7 +9,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
         api: __DIR__.'/../routes/api.php',
-        commands: __DIR__.'/../routes/console.php',
+        console: __DIR__.'/../routes/console.php',
     )
     ->withMiddleware(
         middleware: [


### PR DESCRIPTION
## Summary
- replace `commands` route key with `console`

## Testing
- `php system/artisan` *(fails: Call to undefined method Illuminate\Foundation\Application::configure())*
- `php system/vendor/bin/phpunit --configuration system/phpunit.xml` *(fails: Call to undefined method Illuminate\Foundation\Application::configure())*

------
https://chatgpt.com/codex/tasks/task_e_68af14c8057c8329b845d650d57fb75f