### PR TITLE
Improve curl error handling in payment gateways

### DIFF
--- a/system/app/Http/Controllers/PaymentGateway/LinkQuController.php
+++ b/system/app/Http/Controllers/PaymentGateway/LinkQuController.php
@@ -3,6 +3,7 @@ namespace App\Http\Controllers\PaymentGateway;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 
 class LinkQuController extends Controller
 {
@@ -200,10 +201,11 @@ class LinkQuController extends Controller
               CURLOPT_HTTPHEADER => $headers,
             ));
         }
-        $err = curl_error($curl);
         $ret = curl_exec($curl);
+        $err = curl_error($curl);
         curl_close($curl);
         if ($err) {
+            Log::error('LinkQu API error: ' . $err);
             return $err;
         } else {
             return json_decode($ret);

--- a/system/app/Http/Controllers/PaymentGateway/PaydisiniController.php
+++ b/system/app/Http/Controllers/PaymentGateway/PaydisiniController.php
@@ -110,11 +110,11 @@ class PaydisiniController extends Controller
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
-        
-        $err = curl_error($ch);
         $ret = curl_exec($ch);
+        $err = curl_error($ch);
         curl_close($ch);
         if ($err) {
+            Log::error('Paydisini API error: ' . $err);
             return $err;
         } else {
             return json_decode($ret);

--- a/system/app/Http/Controllers/PaymentGateway/iPaymuController.php
+++ b/system/app/Http/Controllers/PaymentGateway/iPaymuController.php
@@ -117,10 +117,11 @@ class iPaymuController extends Controller
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
-        $err = curl_error($ch);
         $ret = curl_exec($ch);
+        $err = curl_error($ch);
         curl_close($ch);
         if ($err) {
+            Log::error('iPaymu API error: ' . $err);
             return $err;
         } else {
             return json_decode($ret);


### PR DESCRIPTION
## Summary
- log Paydisini API curl errors after execution
- log iPaymu API curl errors after execution
- log LinkQu API curl errors and import Laravel Log facade

## Testing
- `php -l system/app/Http/Controllers/PaymentGateway/PaydisiniController.php`
- `php -l system/app/Http/Controllers/PaymentGateway/iPaymuController.php`
- `php -l system/app/Http/Controllers/PaymentGateway/LinkQuController.php`
- `php vendor/bin/phpunit` *(fails: Call to undefined method Illuminate\Foundation\Application::configure())*


------
https://chatgpt.com/codex/tasks/task_e_68af1aeb59648329b77f6bcea7028822